### PR TITLE
Add typescript to the DevDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
+    "concurrently": "^6.3.0",
     "eslint-plugin-import-alias": "^1.2.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-prettier": "^3.4.0",
@@ -24,7 +25,7 @@
     "lerna": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
-    "concurrently": "^6.3.0"
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "graphql": "^16.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15129,6 +15129,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.2.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
 typescript@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"


### PR DESCRIPTION
After a candidate was not able to run the project locally, we noticed we did not add `typescript` as a dependency to the project 🤦‍♂️ 

**Error from the candidate:**
```
Failed to compile.
Failed to load parser '@typescript-eslint/parser' declared in '.eslintrc » ../../.eslintrc': Cannot find module 'typescript'
Require stack:
- C:\source\traveller\node_modules\@typescript-eslint\typescript-estree\dist\parser.js
- C:\source\traveller\node_modules\@typescript-eslint\typescript-estree\dist\index.js
- C:\source\traveller\node_modules\@typescript-eslint\parser\dist\parser.js
- C:\source\traveller\node_modules\@typescript-eslint\parser\dist\index.js
- C:\source\traveller\packages\client\node_modules\@eslint\eslintrc\lib\config-array-factory.js
- C:\source\traveller\packages\client\node_modules\@eslint\eslintrc\lib\index.js
- C:\source\traveller\packages\client\node_modules\eslint\lib\cli-engine\cli-engine.js
- C:\source\traveller\packages\client\node_modules\eslint\lib\cli-engine\index.js
- C:\source\traveller\packages\client\node_modules\eslint\lib\api.js
- C:\source\traveller\packages\client\node_modules\eslint-webpack-plugin\dist\getESLint.js
- C:\source\traveller\packages\client\node_modules\eslint-webpack-plugin\dist\linter.js
- C:\source\traveller\packages\client\node_modules\eslint-webpack-plugin\dist\index.js
- C:\source\traveller\packages\client\node_modules\eslint-webpack-plugin\dist\cjs.js
- C:\source\traveller\packages\client\node_modules\react-scripts\config\webpack.config.js
- C:\source\traveller\packages\client\node_modules\react-scripts\scripts\start.js
```